### PR TITLE
FIX: put subscriptionIds in the right places

### DIFF
--- a/config/variables/cdssnc-main.yml
+++ b/config/variables/cdssnc-main.yml
@@ -3,10 +3,10 @@ variables:
   var-hubnetwork-managementGroupId: Connectivity
   var-hubnetwork-azfw-configurationFileName: hub-azfw/hub-network.parameters.json
   var-hubnetwork-nva-configurationFileName: hub-nva/hub-network.parameters.json
-  var-hubnetwork-subscriptionId: 4fd845de-f6c8-4e6d-9a87-c21c4ebf7edd
+  var-hubnetwork-subscriptionId: 707f2266-324c-47d8-809f-07801f4b425a
   var-hubnetwork-azfwPolicy-configurationFileName: hub-azfw-policy/azure-firewall-policy.parameters.json
   var-logging-managementGroupId: Management
-  var-logging-subscriptionId: 707f2266-324c-47d8-809f-07801f4b425a
+  var-logging-subscriptionId: f27b081a-aa54-4ab4-9f26-a4c5375dc8fa
   deploymentRegion: canadacentral
   var-identity-managementGroupId: Identity
   var-logging-diagnosticSettingsforNetworkSecurityGroupsStoragePrefix: pubsecnsg


### PR DESCRIPTION
This PR fixes the error that the network subscriptionId was in the wrong place. 